### PR TITLE
pre-commit: fix prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -79,7 +79,9 @@ repos:
     rev: v2.6.2
     hooks:
       - id: prettier
-        additional_dependencies: [prettier-plugin-go-template]
+        additional_dependencies:
+          - prettier@2.6.2
+          - prettier-plugin-go-template@0.0.13
 
   - repo: https://github.com/pre-commit/pre-commit
     rev: v2.19.0

--- a/themes/poetry/layouts/shortcodes/tab.html
+++ b/themes/poetry/layouts/shortcodes/tab.html
@@ -12,7 +12,6 @@
     data-tabs-target="panel"
   >
     {{ $.Inner | markdownify }}
-
   </div>
 {{ else }}
   <div
@@ -23,6 +22,5 @@
     data-tabs-target="panel"
   >
     {{ $.Inner | markdownify }}
-
   </div>
 {{ end }}

--- a/themes/poetry/layouts/shortcodes/tabs.html
+++ b/themes/poetry/layouts/shortcodes/tabs.html
@@ -115,6 +115,5 @@
 
   <div class="tab-content pt-8" id="{{ $.Get "tabID" }}">
     {{ .Inner }}
-
   </div>
 </div>


### PR DESCRIPTION
The prettier hook was broken after adding `additional_dependencies` since that's used to actually install prettier
