### PR TITLE
ci: fail deployment on rollup errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ clean: ## Clean generated files
 
 .PHONY: site
 site: node_modules content/docs ## Build and serve site
+	@test -f assets/assets/app.js || npx rollup --config
 	@npm run dev
 
 node_modules: package.json package-lock.json

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "dev": "concurrently --names=assets,server --prefix-colors=cyan.bold,magenta.bold 'rollup --config --watch' 'hugo server --watch'",
-    "prod": "rollup --config --environment NODE_ENV:production",
+    "prod": "rollup --config --failAfterWarnings --environment NODE_ENV:production",
     "algolia": "atomic-algolia"
   },
   "author": "",


### PR DESCRIPTION
Add [`--failAfterWarnings`](https://rollupjs.org/guide/en/#--failafterwarnings) to rollup so build errors will fail the deploy next time

Also includes a small tweak for fixing `make site` on a clean checkout. Currently, hugo will fail to start before rollup is finished building `assets/assets/app.js` and never try to restart
