### PR TITLE
Allow manually triggering production deployment

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch: {}
 
 jobs:
   deploy-preview:


### PR DESCRIPTION
This allows maintainers to optionally update the documentation as PRs are merged into other Poetry repos rather than needing to wait for the scheduled deployments. See the below screenshot for an example of this change in `main` of my fork.

![image](https://user-images.githubusercontent.com/11155300/172066379-88aa4714-a444-4cf9-a6fe-88f2e9dc9ef9.png)

This is in response to https://github.com/python-poetry/poetry/issues/4864. That issue related to the documentation on the website. The fix in Poetry's source (https://github.com/python-poetry/poetry/pull/5771) was merged, but with the current cron-only website deployment there's a period of time where the issue has been closed but the site has not actually been updated.