### PR TITLE
Clarify local dev doc source

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you want to work on this project locally, follow the instructions below:
 1. Fork this repository
 1. Clone your fork locally
 1. Run `make site`, which will:
-   - Perform a [sparse checkout](https://git-scm.com/docs/git-sparse-checkout) of the `poetry` repo into `content/docs`
+   - Fetch `docs/*.md` from `poetry` repo into `content/docs`
    - Concurrently run `rollup` to compile assets and `hugo` to serve content
 
 The website will now be accessible at <http://localhost:1313> and reload on any changes.


### PR DESCRIPTION
I was confused because I expected to find a sparse checkout under `content/docs`, with the ability to interact with `poetry` repo with git commands.

What actually happens is that a sparse checkout is made only temporary in a temporary folder, and the plain files are copied from the temporary folder to `content/docs`.

For the reader of the this doc it doesn't matter _how_ the `.md` files are fetched from poetry repo. Using sparse checkout is just an internal choice of the `bin/website` script.

----

Side note: IMHO it would be nice to document a single command that allows pointing to a local folder (typically `../poetry/docs`) as an alternative to fetching from the public poetry repo. This would be handy in the use case where I have myself cloned poetry repo for local development, and am working on some doc changes among poetry code changes. If I can do something to make that happen, please let me know.