### PR TITLE
chore: default stable documentation to `1.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ tags = "/blog/tag/:title/"
 description = "Python dependency management and packaging made easy"
 
 [tool.website.config.params.documentation]
-defaultVersion = "1.1"
+defaultVersion = "1.2"
 
 [tool.website.config.markup.goldmark.renderer]
 unsafe = true
@@ -55,8 +55,8 @@ unsafe = true
 keepWhitespace = true
 
 [tool.website.versions]
-"1.1" = "1.1"
 "1.2" = "1.2"
+"1.1" = "1.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Requires https://github.com/python-poetry/poetry/issues/5586.

Add `1.2` documentation to the website, which will become the default version displayed.

I've kept `1.1` since users could still need it during the transition phase.
It might be a good rule to always keep the 2 latest stable versions in the documentation from now on.