### PR TITLE
chore: add `1.2` documentation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ keepWhitespace = true
 
 [tool.website.versions]
 "1.1" = "1.1"
+"1.2" = "1.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
To help people testing release candidates for `1.2`, it would be helpful to have access to the documentation before the final release.

Default will still be `1.1` until final release, after which https://github.com/python-poetry/website/pull/62 will update the default version.