### PR TITLE
Add pagination in blog + handle dark mode in tags pages

### DIFF
--- a/src/css/_content.css
+++ b/src/css/_content.css
@@ -85,7 +85,7 @@
   @apply text-indigo-700 border-indigo-300 bg-indigo-100 bg-opacity-30;
 }
 
-#content main ul:not(.select-menu) {
+#content main ul:not(.select-menu):not(.pagination) {
   @apply list-inside my-8 pl-8;
 }
 
@@ -103,7 +103,7 @@
   counter-increment: count;
 }
 
-#content main ul:not(.select-menu) > li:before {
+#content main ul:not(.select-menu):not(.pagination) > li:before {
   @apply absolute w-1.5 h-1.5 -left-4 bg-blue-400 rounded-full;
   top: 0.825rem;
   content: " ";
@@ -511,4 +511,18 @@ html.dark #content main ol.steps li.step:after {
 /* Heading Permanent links */
 html.dark #content main .header-link:before {
   content: url('data:image/svg+xml; utf-8, <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 448 512"><g><path fill="%23A5B4FC" fill-opacity="60%" d="M341.3 32.43c-17.53-2.875-33.92 8.891-36.83 26.3l-43.54 261.3h64.88l41.79-250.7C370.5 51.83 358.7 35.34 341.3 32.43zM240.4 442.7c-2.906 17.44 8.875 33.92 26.3 36.83C268.5 479.9 270.3 480 272 480c15.36 0 28.92-11.09 31.53-26.73l11.54-69.27h-64.88L240.4 442.7zM80.44 442.7c-2.906 17.44 8.875 33.92 26.3 36.83C108.5 479.9 110.3 480 112 480c15.36 0 28.92-11.09 31.53-26.73L187.1 191.1H122.2L80.44 442.7zM181.3 32.43c-17.53-2.875-33.92 8.891-36.83 26.3L132.9 127.1H197.8l9.789-58.74C210.5 51.83 198.7 35.34 181.3 32.43z"></path><path fill="%237DD3FC" d="M416 127.1h-58.23l-10.67 64H416c17.67 0 32-14.32 32-31.1C448 142.3 433.7 127.1 416 127.1zM0 352c0 17.67 14.33 31.1 32 31.1h58.23l10.67-64H32C14.33 319.1 0 334.3 0 352zM384 319.1H165.8l-10.67 64H384c17.67 0 32-14.33 32-31.1C416 334.3 401.7 319.1 384 319.1zM64 191.1h218.2l10.67-64H64c-17.67 0-32 14.33-32 32C32 177.7 46.33 191.1 64 191.1z"></path></g></svg>');
+}
+
+/* Pagination */
+#content main ul.pagination li {
+  display: inline-block;
+  margin: 0 5px;
+}
+
+#content main ul.pagination li.active a {
+  @apply text-primary-200;
+}
+
+html.dark #content main ul.pagination li.active a {
+  @apply text-dark-primary;
 }

--- a/themes/poetry/layouts/blog/list.html
+++ b/themes/poetry/layouts/blog/list.html
@@ -12,6 +12,8 @@
           </div>
         </section>
       {{ end }}
+
+      {{ template "_internal/pagination.html" . }}
     {{ end }}
   </main>
 {{ end }}

--- a/themes/poetry/layouts/categories/list.html
+++ b/themes/poetry/layouts/categories/list.html
@@ -12,6 +12,8 @@
           </div>
         </section>
       {{ end }}
+
+      {{ template "_internal/pagination.html" . }}
     {{ end }}
   </main>
 {{ end }}

--- a/themes/poetry/layouts/tags/baseof.html
+++ b/themes/poetry/layouts/tags/baseof.html
@@ -4,6 +4,7 @@
 
 
   <body>
+    {{- partial "dark_mode.html" . -}}
     {{- partial "header.html" . -}}
     <div id="content">
       {{ block "main" . }}{{ end }}

--- a/themes/poetry/layouts/tags/list.html
+++ b/themes/poetry/layouts/tags/list.html
@@ -12,6 +12,8 @@
           </div>
         </section>
       {{ end }}
+
+      {{ template "_internal/pagination.html" . }}
     {{ end }}
   </main>
 {{ end }}


### PR DESCRIPTION
There are 3 paginated lists in the blog:
- blog posts
- categories
- tags

All of them handle pagination already, but the pagination is not displayed, as can be seen [here](https://python-poetry.org/blog/) for instance.
Documentation from Hugo about the pagination: https://gohugo.io/templates/pagination/#build-the-navigation

Also added https://github.com/python-poetry/website/commit/794d373398da6ba9404d9254425d38b1817530a0 to handle dark mode in tags pages, since [this is not the case](https://python-poetry.org/blog/tag/1.1/) today.