### PR TITLE
chore(ci): add concurrency to avoid concurrent doc preview builds

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,6 +11,10 @@ on:
       - labeled
       - synchronize
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   deploy-preview:
     name: Build & Deploy


### PR DESCRIPTION
Avoid concurrent builds on PRs by adding `concurrency`.