### PR TITLE
Fixed broken link

### DIFF
--- a/content/blog/2022-08-31-announcing-poetry-1-2-0.md
+++ b/content/blog/2022-08-31-announcing-poetry-1-2-0.md
@@ -443,7 +443,7 @@ $ poetry config --local installer.no-binary :none:
 ```
 
 Full documentation of this feature (including configuration using environment variables for CI or containers) is
-available [here][no-binary docs].
+available [here][installer.no-binary docs].
 
 [bdist docs]: https://packaging.python.org/en/latest/specifications/binary-distribution-format/
 


### PR DESCRIPTION
Should fix the broken link I noticed at the end of [this section](https://python-poetry.org/blog/announcing-poetry-1.2.0/#opting-out-of-binary-distributions)