### PR TITLE
fix: don't fail the entire build if building the search index fails

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -59,6 +59,7 @@ jobs:
         run: hugo -v --minify
 
       - name: Build search index
+        continue-on-error: true
         env:
           ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
           ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}


### PR DESCRIPTION
The entire site is currently blocked by hitting Algolia free tier limits. We can revert this later if desired, but until then we need to deploy even if we get an error back.
