### PR TITLE
Correcting URL to Github discussions

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -123,7 +123,7 @@
 
               <li>
                 <a
-                  href="https://github.com/python-poetry/discussions"
+                  href="https://github.com/python-poetry/poetry/discussions"
                   class="text-base opacity-80 hover:opacity-100"
                 >
                   Discussions


### PR DESCRIPTION
Just fixing URL from `/python-poetry/discussions` to `/python-poetry/poetry/discussions` since I get a 404 with current value.