### PR TITLE
Update "Writing lock file" placement

### DIFF
--- a/layouts/home.html
+++ b/layouts/home.html
@@ -71,13 +71,13 @@ Using version <span class="text-white font-semibold">^2.0.5</span> for <span cla
 <span class="text-blue-300">Updating dependencies</span>
 <span class="text-blue-300">Resolving dependencies</span>... <span class="text-gray-600">(1.5s)</span>
 
-<span class="text-blue-300">Writing lock file</span>
-
 Package operations: <span class="text-blue-300">4</span> installs, <span class="text-blue-300">0</span> updates, <span class="text-blue-300">0</span> removals
 
   - Installing <span class="text-cyan-300">six</span> (<span class="text-white font-semibold">1.13.0</span>): <span class="text-blue-300">Downloading...</span> <span class="text-white font-semibold">25%</span>
   - Updating <span class="text-cyan-300">pytzdata</span> (<span class="text-white font-semibold">2019.3</span> -> <span class="text-white font-semibold">2020.4</span>): <span class="text-blue-300">Installing...</span>
   - Installing <span class="text-cyan-300">pendulum</span> (<span class="text-green-300">2.0.5</span>)
+
+<span class="text-blue-300">Writing lock file</span>
 </code></pre>
       </div>
     </div>


### PR DESCRIPTION
After python-poetry/poetry#7498, the output "Writing lock file" is now at the end of `poetry add` command.

This PR updates the output displayed in the front page https://python-poetry.org/

## Screenshot (with the change)
![image](https://user-images.githubusercontent.com/428341/230657285-4832ea7d-73e4-4511-bcb7-661f8df6095c.png)
