### PR TITLE
Fix page summary for non-default version.

### DIFF
--- a/layouts/partials/documentation_flyover.html
+++ b/layouts/partials/documentation_flyover.html
@@ -56,7 +56,7 @@
                 <p
                   class="mt-1 text-sm overflow-hidden overflow-ellipsis opacity-60"
                 >
-                  {{- safeHTML (strings.TrimPrefix .Name (index (split .Page.Summary ". ") 0)) -}}.
+                  {{- safeHTML (strings.TrimPrefix (index (split .Name "|") 0) (index (split .Page.Summary ". ") 0)) -}}.
                 </p>
               </div>
             </a>


### PR DESCRIPTION
It seems that section summaries in the documentation flyover are not rendered correctly when looking at a non-default version, e.g., currently https://python-poetry.org/docs/1.5/.

The cause is that the removal of the section title from `.Page.Summary` via `strings.TrimPrefix .Name` doesn't work for pages in non-default versions since the titles contain a suffix with the version number, e.g., `Introduction | 1.5`.

This is accounted for when rendering the section title in a separate paragraph above, but not when rendering the excerpt from the section body.

This PR fixes that by using the same `index (split .Name "|") 0` construct that correctly extracts the section title.