### PR TITLE
Increasing the visibility of -code copy- icon

### DIFF
--- a/src/css/_clipboard.css
+++ b/src/css/_clipboard.css
@@ -6,7 +6,7 @@
   color: rgb(14 165 233 / var(--tw-border-opacity));
   --tw-border-opacity: 0.4;
   background-color: rgb(186 230 253 / var(--tw-bg-opacity));
-  --tw-bg-opacity: 0.1;
+  --tw-bg-opacity: 0.5;
   border: 1px solid rgb(14 165 233 / var(--tw-border-opacity));
   border-radius: 6px;
   font-size: 0.8em;


### PR DESCRIPTION
Fixes the issue #155

Fixed the issue with the "code copy" icon's visibility being low. 