### PR TITLE
ci: use npm installed hugo to reduce the number of hard-coded hugo versions

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -56,13 +56,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           env: Preview
 
-      - name: Install Hugo
-        uses: peaceiris/actions-hugo@v2
-        with:
-          hugo-version: "0.139.2"
-
       - name: Build
-        run: hugo --buildDrafts --buildFuture --logLevel info
+        run: npx hugo --buildDrafts --buildFuture --logLevel info
 
       - name: Deploy
         uses: amondnet/vercel-action@v25

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -50,13 +50,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           env: Production
 
-      - name: Install Hugo
-        uses: peaceiris/actions-hugo@v2
-        with:
-          hugo-version: "0.139.2"
-
       - name: Build
-        run: hugo --minify --logLevel info
+        run: npx hugo --minify --logLevel info
 
       - name: Build search index
         continue-on-error: true


### PR DESCRIPTION
As proposed in [python-poetry/poetry#9879](https://github.com/python-poetry/poetry/pull/9879#discussion_r1863846110)