### PR TITLE
ci: fix building the search index

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -29,14 +29,17 @@ jobs:
         with:
           node-version: "18"
 
+      - name: Build Assets
+        run: npm ci && npm run prod
+
+      # Ruby must be set up after running "npm ci" because installing hugo-bin via npm
+      # removes the vendor directory that is created by "bundle install"
+      # https://github.com/fenneclab/hugo-bin/blob/a5500e4f622f46886947d3438243bd97cfe6c04c/lib/install.js#L28-L30
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
           bundler-cache: true
-
-      - name: Build Assets
-        run: npm ci && npm run prod
 
       - name: Fetch Documentation
         run: |


### PR DESCRIPTION
Building the search index fails since the `hugo` update in #159:

- last successful run: https://github.com/python-poetry/website/actions/runs/12076967191
- first failure: https://github.com/python-poetry/website/actions/runs/12082967521

The failure is caused by `hugo-bin` (since `v0.102.0`) removing the `vendor` directory, which is created by `bundle install` while setting up ruby, during installation: https://github.com/fenneclab/hugo-bin/compare/v0.101.5...v0.102.0

The following runs of a temporarily changed `Deploy Preview` workflow show that this PR fixes the issue (the index is normally only built in the `Deploy Production` workflow):

- without fix: https://github.com/python-poetry/website/actions/runs/12569633498
- with fix: https://github.com/python-poetry/website/actions/runs/12571042788