### PR TITLE
fix: prevent tab anchor from overriding non-tab URL hashes

### DIFF
--- a/src/js/controllers/tabs_controller.js
+++ b/src/js/controllers/tabs_controller.js
@@ -9,8 +9,11 @@ export default class extends Controller {
       this.data.get("inactiveTab") || "inactive"
     ).split(" ")
     if (this.anchor) {
-      this.index = this.tabTargets.findIndex((tab) => tab.id === this.anchor)
-      this.showTab()
+      const index = this.tabTargets.findIndex((tab) => tab.id === this.anchor)
+      if (index >= 0) {
+        this.index = index
+        this.showTab()
+      }
     }
   }
 


### PR DESCRIPTION
When visiting a URL with a non-tab anchor like `/docs/cli/#add`, the tabs controller 
was replacing it with the first tab's ID (e.g. `#script-project`) because `findIndex` 
returns `-1` for no match, which defaults to index `0`.

Added a guard so `showTab()` is only called when the anchor actually matches a tab ID.