### PR TITLE
ci: replace deployment action with builtin deployment support

### DIFF
--- a/.github/workflows/deploy-preview.yaml
+++ b/.github/workflows/deploy-preview.yaml
@@ -26,8 +26,10 @@ jobs:
     if: |
       (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe'))
       || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
+    environment:
+      name: Preview
+      url: ${{ steps.vercel-action.outputs.preview-url }}
     permissions:
-      deployments: write
       pull-requests: write
     steps:
       - name: Checkout
@@ -55,14 +57,6 @@ jobs:
           poetry install --no-root --only main
           poetry run python bin/website build
 
-      - name: Start Deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
-        id: deployment
-        with:
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: Preview
-
       - name: Build
         run: npx hugo --buildDrafts --buildFuture --logLevel info
 
@@ -78,14 +72,3 @@ jobs:
           scope: python-poetry
           github-comment: true
           working-directory: public
-
-      - name: Update Deployment Status
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
-        if: always()
-        with:
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: ${{ steps.vercel-action.outputs.preview-url }}
-          env: ${{ steps.deployment.outputs.env }}

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -11,12 +11,14 @@ on:
 permissions: {}
 
 jobs:
-  deploy-preview:
+  deploy-production:
     name: Build & Deploy
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment:
+      name: Production
+      url: ${{ steps.vercel-action.outputs.preview-url }}
     permissions:
-      deployments: write
       pull-requests: write
 
     steps:
@@ -53,14 +55,6 @@ jobs:
           poetry install --no-root --only main
           poetry run python bin/website build
 
-      - name: Start Deployment
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
-        id: deployment
-        with:
-          step: start
-          token: ${{ secrets.GITHUB_TOKEN }}
-          env: Production
-
       - name: Build
         run: npx hugo --minify --logLevel info
 
@@ -88,14 +82,3 @@ jobs:
           github-comment: false
           vercel-args: "--prod"
           working-directory: public
-
-      - name: Update Deployment Status
-        uses: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8 # v1.5.0
-        if: always()
-        with:
-          step: finish
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: ${{ job.status }}
-          deployment_id: ${{ steps.deployment.outputs.deployment_id }}
-          env_url: ${{ steps.vercel-action.outputs.preview-url }}
-          env: ${{ steps.deployment.outputs.env }}


### PR DESCRIPTION
We get the following warning in our actions:

```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: bobheadxi/deployments@648679e8e4915b27893bd7dbc35cb504dc915bc8.
Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026.
Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

`bobheadxi/deployments` may be unmaintained:

- last commit two years ago
- https://github.com/bobheadxi/deployments/issues/169

However, we probably do not even need a custom action but can just rely on github's builtin deployment mechanism.
